### PR TITLE
docs: fix monorepo wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # funded_projects
-Mono repo for Flurrylab funded projects
+Monorepo for FlurryLab-funded projects


### PR DESCRIPTION
## Summary
- clarify README text to refer to this repository as a "Monorepo" and correct capitalization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fffd170a883318e666f24d0ac4f52